### PR TITLE
Allow private repos by passing GITHUB_TOKEN.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: build
+
+build:
+	GOOS=linux go build -o function .
+
+package: build
+	$(eval TAG := $(shell git describe --abbrev=0 --tags))
+	mkdir reposync-cloud-function-$(TAG)
+	mv function reposync-cloud-function-$(TAG)/
+	cp index.js reposync-cloud-function-$(TAG)/
+	zip -r -9 reposync-cloud-function-$(TAG).zip reposync-cloud-function-$(TAG)/
+	rm -fr reposync-cloud-function-$(TAG)/

--- a/function.go
+++ b/function.go
@@ -91,7 +91,19 @@ func mirrorGitHubCloudSourceRepositories(githubRepo *github.PushEventRepository)
 		return fmt.Errorf("Unable to clone the %s repo: %s", *githubRepo.CloneURL, err)
 	}
 
-	cmd := exec.Command("git", "clone", "--mirror", *githubRepo.CloneURL, dir)
+	githubRepoURL := *githubRepo.URL
+
+	githubToken := os.Getenv("GITHUB_TOKEN")
+	if githubToken != "" {
+		parsedURL, err := url.Parse(githubRepoURL)
+		if err != nil {
+			return err
+		}
+		parsedURL.User = url.UserPassword(githubToken, "x-oauth-basic")
+		githubRepoURL = parsedURL.String()
+	}
+
+	cmd := exec.Command("git", "clone", "--mirror", githubRepoURL, dir)
 	output, err := cmd.CombinedOutput()
 	log.Println(output)
 	if err != nil {


### PR DESCRIPTION
Private repos can be cloned by setting the GITHUB_TOKEN environment variable.

Fixes #2 